### PR TITLE
Screen size navigation and blog-page fixes

### DIFF
--- a/app/src/components/ListDetail/ListDetailView.tsx
+++ b/app/src/components/ListDetail/ListDetailView.tsx
@@ -15,7 +15,7 @@ export function ListDetailView({
                 <div
                     id="list"
                     className={`bg-dots ${
-                        hasDetail ? 'hidden lg:flex' : 'min-h-screen w-full'
+                        hasDetail ? 'hidden xl:flex' : 'min-h-screen w-full'
                     }`}
                 >
                     {list}

--- a/app/src/components/TitleBar/index.tsx
+++ b/app/src/components/TitleBar/index.tsx
@@ -144,7 +144,7 @@ export function TitleBar({
                         {backButton && (
                             <Link
                                 href={backButtonHref}
-                                className="flex items-center justify-center p-2 rounded-md text-primary hover:bg-gray-200 dark:hover:bg-gray-800 lg:hidden"
+                                className="flex items-center justify-center p-2 rounded-md text-primary hover:bg-gray-200 dark:hover:bg-gray-800 xl:hidden"
                             >
                                 <FaArrowLeft className="text-primary" />
                             </Link>


### PR DESCRIPTION
Purpose: Allow more space for the blog content when the screen size is `lg`, i.e., 1024px.

This specifically hides the middle navigation menu (which blog/writing section you're on), and shows the go-back button for fixing the navigation from such a blog-page.